### PR TITLE
Original information link is now invalid

### DIFF
--- a/readme.creole
+++ b/readme.creole
@@ -7,7 +7,9 @@ hostnames you wish to exclude can be specified in a list with -e. If you
 want to query for a domain group and highlight where those users are
 logged in from, specify the group with -g.
 
-Info & Compiled version: http://www.room362.com/blog/2012/10/8/compiling-and-release-of-netview.html
+Info: http://web.archive.org/web/20130301022254/http://www.room362.com/blog/2012/10/8/compiling-and-release-of-netview.html
+
+Compiled version: http://www.room362.com/storage/netview.exe
 
 Once a list is gathered, netview check each for the following
 + IP addresses


### PR DESCRIPTION
Originally there was one link for information and the compiled version of netview.exe. For some reason, that link is no longer valid. Thus, I've replaced the info link with the Archive.org storage of the page and I've put in a direct link to the compiled version.